### PR TITLE
refactor(aoc_2018/day01): extract read input to common.rs

### DIFF
--- a/src/aoc_2018/day_01/common.rs
+++ b/src/aoc_2018/day_01/common.rs
@@ -1,0 +1,8 @@
+use std::{fs, num};
+
+pub fn read_input() -> Result<Vec<i32>, num::ParseIntError>{
+    fs::read_to_string("src/aoc_2018/day_01/input.txt").unwrap()
+        .lines()
+        .map(|line| line.parse::<i32>())
+        .collect::<Result<Vec<_>, _>>()
+}

--- a/src/aoc_2018/day_01/part_1.rs
+++ b/src/aoc_2018/day_01/part_1.rs
@@ -1,16 +1,15 @@
-use std::{fs, num};
+use std::num;
+#[path="common.rs"]
+mod common;
 
-fn resulting_frequency(input: String) -> Result<i32, num::ParseIntError> {
+fn resulting_frequency(input: Vec<i32>) -> Result<i32, num::ParseIntError> {
     Ok(input
-        .lines()
-        .map(|line| line.parse::<i32>())
-        .collect::<Result<Vec<_>, _>>()?
         .iter()
         .sum())
 }
 
 pub fn run() -> Result<(), num::ParseIntError> {
-    let input = fs::read_to_string("src/aoc_2018/day_01/input.txt").unwrap();
+    let input = common::read_input().unwrap();
     let result = resulting_frequency(input)?;
     println!("{:?}", result);
     Ok(())
@@ -18,7 +17,7 @@ pub fn run() -> Result<(), num::ParseIntError> {
 
 #[test]
 fn first_input_returns_3() -> Result<(), num::ParseIntError> {
-    let input = "+1\n+1\n+1".to_string();
+    let input = vec![1,1,1];
     let actual = resulting_frequency(input)?;
     assert_eq!(3, actual);
     Ok(())
@@ -26,7 +25,7 @@ fn first_input_returns_3() -> Result<(), num::ParseIntError> {
 
 #[test]
 fn second_input_returns_0() -> Result<(), num::ParseIntError> {
-    let input = "+1\n+1\n-2".to_string();
+    let input = vec![1, 1, -2];
     let actual = resulting_frequency(input)?;
     assert_eq!(0, actual);
     Ok(())
@@ -34,7 +33,7 @@ fn second_input_returns_0() -> Result<(), num::ParseIntError> {
 
 #[test]
 fn third_input_returns_minus_6() -> Result<(), num::ParseIntError> {
-    let input = "-1\n-2\n-3".to_string();
+    let input = vec![-1,-2,-3];
     let actual = resulting_frequency(input)?;
     assert_eq!(-6, actual);
     Ok(())

--- a/src/aoc_2018/day_01/part_2.rs
+++ b/src/aoc_2018/day_01/part_2.rs
@@ -1,11 +1,9 @@
 use std::{collections::HashSet, fs};
+#[path="common.rs"]
+mod common;
 
 pub fn run() -> i32 {
-    let frequencies = fs::read_to_string("day_1.txt")
-        .unwrap()
-        .lines()
-        .map(|line| line.parse::<i32>().unwrap())
-        .collect::<Vec<_>>();
+    let frequencies = common::read_input().unwrap();
 
     let mut seen = HashSet::new();
     seen.insert(0);


### PR DESCRIPTION
He movido lo de leer el input a otro archivo (`common.rs`) para reutilizarlo desde alli en ambas partes del ejercicio.